### PR TITLE
Remove "Recommended for you" videos from recomends

### DIFF
--- a/yt-neuter.txt
+++ b/yt-neuter.txt
@@ -119,6 +119,9 @@ youtube.com##.badge:has(span:has-text(Fundraiser))
 youtube.com##.badge:has(span:has-text(New))
 ! nudges (recommendation/ turn on watch history)
 youtube.com##ytd-feed-nudge-renderer
+! "Recommended for you" sponsored videos
+! Looks for non-live videos without 2 spans in the metadata-line (on normal videos, there's view count + upload date)
+youtube.com##ytd-compact-video-renderer:not(:has(#metadata-line span:nth-of-type(2))):not(:has(.secondary-metadata > ytd-badge-supported-renderer > .badge-style-type-live-now-alternate))
 
 ## channel page
 ! recognized channel member


### PR DESCRIPTION
closes #1
A pretty complicated filter exploits the fact that "Recommended for you" videos don't show view count & upload date.
Currently live streams don't show upload date, which caused them to be caught by the filter, so I had to exclude those.
Past livestreams thankfully do show a stream date.