### PR TITLE
Hide generic shorts shelf on mobile

### DIFF
--- a/filters/noshorts.txt
+++ b/filters/noshorts.txt
@@ -12,6 +12,7 @@
 !! shelves
 ! generic shorts shelf (channel, search)
 youtube.com##ytd-reel-shelf-renderer
+m.youtube.com##ytm-reel-shelf-renderer
 
 !!!! global elements
 !!! sidebar navigation


### PR DESCRIPTION
To reproduce:

1. Change your browser's user agent to a [mobile Safari version](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#safari_ua_string), e.g.:
```
Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1
```
2. Go to `https://m.youtube.com`, and confirm the URL stays at that subdomain instead of redirecting to `https://www.youtube.com`.

There should be a shorts section visible before this change on the home feed, which is hidden after it is applied.