### PR TITLE
Port "Watch on YouTube" rule

### DIFF
--- a/filters/sponsorblock.txt
+++ b/filters/sponsorblock.txt
@@ -82,6 +82,8 @@ www.youtube.com##ytd-comment-renderer#comment:style(--ytd-comment-paid-backgroun
 
 !!! recommendations sidebar
 !! recommendations
+! watch on youtube
+youtube.com##.ytd-tvfilm-offer-module-renderer
 ! nudges (recommendation/ turn on watch history)
 www.youtube.com##ytd-feed-nudge-renderer
 


### PR DESCRIPTION
The rule to remove this is already in the main filter list. Add it to the SponsorBlock one as well.

![image](https://github.com/user-attachments/assets/ce7d28d3-680f-40bc-a2b8-58725e1501a9)
