### PR TITLE
[sponsorblock] Fix typo in #71 and re-add dropped www prefix

### DIFF
--- a/filters/sponsorblock.txt
+++ b/filters/sponsorblock.txt
@@ -109,7 +109,7 @@ www.youtube.com##ytd-comment-renderer#comment:style(--ytd-comment-paid-backgroun
 
 !!! recommendations sidebar
 ! watch on youtube
-youtube.com##ytd-tvfilm-offer-module-renderer
+www.youtube.com##ytd-tvfilm-offer-module-renderer
 ! nudges (recommendation/ turn on watch history)
 www.youtube.com##ytd-feed-nudge-renderer
 !! video-specific sidebar

--- a/filters/sponsorblock.txt
+++ b/filters/sponsorblock.txt
@@ -109,7 +109,7 @@ www.youtube.com##ytd-comment-renderer#comment:style(--ytd-comment-paid-backgroun
 
 !!! recommendations sidebar
 ! watch on youtube
-youtube.com##.ytd-tvfilm-offer-module-renderer
+youtube.com##ytd-tvfilm-offer-module-renderer
 ! nudges (recommendation/ turn on watch history)
 www.youtube.com##ytd-feed-nudge-renderer
 !! video-specific sidebar


### PR DESCRIPTION
When this rule was ported from the main list to the SponsorBlock list in https://github.com/mchangrh/yt-neuter/pull/71, it appears that an extra `.` was added to the rule.

I also re-added the dropped www prefix.

---

At the time of that commit, the corresponding rule in the main list was:

```adblock
www.youtube.com##ytd-tvfilm-offer-module-renderer
```