### PR TITLE
remove ai "Ask" button

### DIFF
--- a/yt-neuter.txt
+++ b/yt-neuter.txt
@@ -272,6 +272,8 @@ www.youtube.com##yt-button-view-model:has(>button-view-model> button[aria-label=
 m.youtube.com##button-view-model:has(button[aria-label="Save to playlist"])
 ! hide disabled buttons (download for non-premium, save for yt kids), exclude comment save/submit (#36)
 www.youtube.com##ytd-button-renderer:has(>yt-button-shape:has(>button.yt-spec-button-shape-next--disabled)):not(.ytd-commentbox)
+! remove ai "Ask" button
+www.youtube.com##yt-button-view-model:has(>button-view-model> button[aria-label="Ask"])
 
 !!! description box
 ! stop scrolling on "show less" (ubo only)


### PR DESCRIPTION
Dedicated line to remove the gemini "Ask" button, useful to have if the filters have been modified to still show other buttons

Removes this button:
<img width="139" height="83" alt="image" src="https://github.com/user-attachments/assets/1e4e87a2-2138-4f36-a2f2-a2023dbf4a95" />
