### PR TITLE
[yt-neuter] hide sponsorship gift announcements

### DIFF
--- a/yt-neuter.txt
+++ b/yt-neuter.txt
@@ -1,6 +1,6 @@
 [uBlock Origin]
 ! Title: YouTube Neuter
-! Last modified: 2026/02/08
+! Last modified: 2026/02/13
 ! Expires: 1 day
 ! Homepage: https://github.com/mchangrh/yt-neuter
 ! Licence: Unlicense
@@ -420,6 +420,8 @@ youtube.com##yt-live-chat-text-message-renderer:not(:has(#message:min-text-lengt
 !! non-text messages
 ! superchats
 youtube.com##yt-live-chat-paid-message-renderer
+! sponsorships
+youtube.com##ytd-sponsorships-live-chat-gift-purchase-announcement-renderer
 ! memberships
 youtube.com##yt-live-chat-membership-item-renderer
 


### PR DESCRIPTION
Hides the “gifted membership” banners in the live chat to reduce visual noise.